### PR TITLE
Update NavigationState.js

### DIFF
--- a/src/modules/navigation/NavigationState.js
+++ b/src/modules/navigation/NavigationState.js
@@ -86,9 +86,10 @@ export default function NavigationReducer(state = initialState, action) {
 
     case SWITCH_TAB: {
       // Switches the tab.
-      const tabs = NavigationStateUtils.jumpToIndex(state.get('tabs').toJS(), action.payload);
-      if (tabs !== state.get('tabs')) {
-        return state.set('tabs', fromJS(tabs));
+      const tabs = state.get('tabs').toJS();
+      const nextTabs = NavigationStateUtils.jumpToIndex(tabs, action.payload);
+      if (tabs !== nextTabs) {
+        return state.set('tabs', fromJS(nextTabs));
       }
       return state;
     }


### PR DESCRIPTION
Fixed SWITCH_TAB logic.

Previously, tabs !== state.get('tabs') always returns true.